### PR TITLE
중복 문장 제거

### DIFF
--- a/docs/paper/Part 2. Creating a Standard/8-the-first-tc39-meeting.mdx
+++ b/docs/paper/Part 2. Creating a Standard/8-the-first-tc39-meeting.mdx
@@ -15,8 +15,6 @@ Microsoft Internet Explorer 개발팀 리더 Thomas Reardon은 위원회가 HTML
 
 제안된 의제에는 먼저 Netscape, Sun, Microsoft, Nombas Inc.의 기술 발표가 있었다. 그뿐만 아니라 새로운 Ecma 기술 위원회를 설립하고 표준 언어 명세를 작성하는 작업을 시작하는 데 필요한 실제 조직 활동도 의제에 있었다. 그러나 회의에서 선은 아무것도 발표할 필요가 없다고 말했고, Borland International의 발표가 추가로 포함되었다.
 
-Netscape와 Borland는 회의가 시작할 때 기술 명세의 초안을 배포하였다. Microsoft는 그렇지 않았다. Thomas Reardon의 발표 중에, Microsoft가 자체적으로 초안 명세를 개발했다며 문서를 들어 보였다. Reardon은 아직 복사본을 준비하지 못했지만 다음 날 복사본을 제공할 것이라고 주장했으므로, Microsoft의 기술 발표는 회의 둘째 날로 이동되었다.
-
 Netscape와 Borland는 회의 시작 시 기술 명세 초안을 배포했다. Microsoft는 그러지 않았다. Thomas Reardon이 발표 중에 Microsoft가 초안 명세를 개발했다고 언급하며 문서를 들어 보였다. Reardon은 아직 시간이 부족해서 복사본을 준비하지 못했고 다음 날 복사본을 제공할 거라고 했다. 그래서 Microsoft의 기술 발표는 회의 둘째 날로 미뤄졌다.
 
 Brendan Eich도 그 자리에 참석했지만, Netscape의 기술 발표는 Anh Nguyen이 진행했다. 그 발표에서는 Eich와 C. Rand McKinny가 작성한 JavaScript 1.1의 JavaScript 언어 명세 초안을 소개했다 [1996]. Netscape는 이를 Ecma에 기여하여 표준화 노력의 기초 문서 중 하나가 되도록 했다. Nguyen은 Netscape Navigator 3의 JavaScript 1.1이 Netscape 2의 초기 JavaScript 버전과 몇 가지 차이가 있다고 설명했다. Netscape의 명세는 ANSI C 언어 표준 [ANSI X3 1989]에서 사용된 것과 유사한 BNF 표기법을 사용하여 언어 구문을 기술했다. 대부분의 시맨틱을 비공식적인 산문체로 썼고 언어의 강제 형변환 규칙을 기술하기 위해서는 표 형식을 사용했다.


### PR DESCRIPTION
같은 문장이 두 번 번역된 부분을 제거합니다. 더 자연스럽게 번역된 문장을 남겨놓았습니다.